### PR TITLE
🛠️ Refactor: Enhance workflow stability and error reporting

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -32,6 +32,7 @@ jobs:
           commit-message: Updater script changes
           branch: updater-bot
           delete-branch: true
+          base: ${{ github.head_ref || github.ref_name }}
           title: "Updater: stuff changed"
           body: |
             Changes caused from update scripts
@@ -48,7 +49,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.124.1'
 
       - name: Build
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Project Conventions
+
+## General Guidelines
+- **Centralized Error Reporting:** All expected or unexpected errors in scripts and code paths must funnel through a centralized reporting function. Do not leave empty catch blocks or swallow errors.
+- **Tooling:** Use `mise` for environment setup, task management, linting, and formatting. Tool versions in `mise.toml` (e.g., `go`, `hugo`) must be explicitly pinned. Latest or LTS are not actual versions.
+- **Continuous Integration:** `.github/workflows/gh-pages.yaml` (and similar workflows) enforce a flow of install -> codegen -> PR (if changes) -> CI -> release -> artifacts (GitHub Pages).
+- **PR Automation:** The `create-pull-request` action requires `base: ${{ github.head_ref || github.ref_name }}` to handle `pull_request` events correctly without detached HEAD errors.
+
+## Operational Memory (Project Structure)
+- `hugo.toml` -> Hugo website configuration.
+- `layouts/` -> Hugo templates for pages and shortcodes.
+- `content/` -> Markdown and content files for the static site.
+- `update.sh` -> Codegen and update scripts entrypoint.
+- `.github/workflows/` -> CI/CD pipelines (GitHub Pages deployment).
+- `mise.toml` -> Pinned tooling versions and task definitions (e.g. `test`, `codegen`, `lint`).

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,12 @@
+[tools]
+go = "1.22.2"
+hugo = "0.124.1"
+
+[tasks.test]
+run = "hugo --minify"
+
+[tasks.codegen]
+run = "./update.sh"
+
+[tasks.ci]
+run = "mise run test"

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+set -e
+
+reportError() {
+  local exit_code=$?
+  echo "Error occurred in update.sh at line ${1:-$LINENO}. Exit code: $exit_code." >&2
+  exit $exit_code
+}
+
+trap 'reportError ${LINENO}' ERR
 
 for item in $(find -executable -type f | grep update_); do
   echo Running "$item"


### PR DESCRIPTION
### Assumptions
- The tool versions for `go` (1.22.2) and `hugo` (0.124.1) correctly match the system requirements.
- Adding a centralized error handler via `trap` in `update.sh` will effectively capture script failures.

### Alternatives Not Chosen
- Skipping `mise.toml` generation and leaving `gh-pages.yaml` intact, which would violate the explicitly requested rules around tool pinning and detached HEAD errors.
- Extracting bash logic into separate files, as the script is small enough to be handled directly by `set -e` and a `trap` for error reporting.

### How To Pivot
- If the tool versions need updating, you can modify `mise.toml` and `.github/workflows/gh-pages.yaml` to the new pinned versions.
- If the error reporting mechanism in `update.sh` is too noisy, the `trap` command can be removed.

### Next Knobs
- `mise.toml` tasks can be expanded for more complex workflows (`fmt`, `lint`).
- `update.sh` error reporting can be integrated with a reporting service (e.g., Sentry) if required in the future.
- The `gh-pages.yaml` file could include more explicit caching configurations.

---
*PR created automatically by Jules for task [13972876237854653240](https://jules.google.com/task/13972876237854653240) started by @lucasew*