### PR TITLE
🛠️ Refactor: Enhance structure and error reporting

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -30,6 +30,7 @@ jobs:
         id: pr_create
         with:
           commit-message: Updater script changes
+          base: ${{ github.head_ref || github.ref_name }}
           branch: updater-bot
           delete-branch: true
           title: "Updater: stuff changed"
@@ -48,7 +49,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.145.0'
 
       - name: Build
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Project Conventions and Guidelines
+
+## Directory Mapping
+* `layouts/` -> Hugo HTML templates
+* `content/` -> Markdown content files
+* `update.sh` -> Codegen / updaters entrypoint script
+* `.github/workflows/` -> GitHub Actions workflows
+
+## Rules
+* **No `latest` or `lts` Versions**: Always pin tools (`hugo`, `go`, etc.) and GitHub Actions to specific versions. "latest" and "lts" are not allowed as they lead to unpredictable builds.
+* **Centralized Error Handling**: Scripts and code paths must use a centralized error reporting mechanism. Empty catch blocks or silent failures are strictly forbidden. Scripts like `update.sh` use a centralized `reportError` function hooked via `trap ... ERR`.
+* **GitHub Actions Base Ref**: In GitHub Actions using `create-pull-request` (e.g. `gh-pages.yaml`), always pass `base: ${{ github.head_ref || github.ref_name }}` to handle `pull_request` events correctly and prevent detached HEAD errors.
+* **Mise Tasks**: The project uses `mise` for environment setup and task management. Use `mise run lint`, `mise run test`, `mise run ci`, `mise run codegen` as standard entries.
+
+## PR Standards
+* **Refactor PRs**: Pull Requests must be titled exactly '🛠️ Refactor: [Description]'.
+* **PR Sections**: Include mandatory sections in PR descriptions: 'Assumptions', 'Alternatives Not Chosen', 'How To Pivot', and 'Next Knobs'.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,7 @@
+[tools]
+hugo = "0.145.0"
+
+[tasks]
+codegen = "./update.sh"
+ci = "mise run test"
+test = "hugo --minify"

--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 
-for item in $(find -executable -type f | grep update_); do
-  echo Running "$item"
-  $item
-done
+set -e
+set -o pipefail
+
+reportError() {
+  local line=$1
+  local cmd=$2
+  echo "::error file=$0,line=$line::Command '$cmd' failed"
+  exit 1
+}
+
+trap 'reportError ${LINENO} "$BASH_COMMAND"' ERR
+
+files=$(find . -executable -type f | grep update_ | grep -v "update.sh" || true)
+if [ -n "$files" ]; then
+  for item in $files; do
+    echo "Running $item"
+    "$item"
+  done
+fi


### PR DESCRIPTION
🛠️ Refactor: Enhance structure and error reporting

This PR addresses several retroactive rule violations and structural improvements based on the project conventions and global directives.

### Assumptions
- A specific recent version of Hugo (0.145.0) is safe to pin and resolves the strict "no 'latest' versions" directive without breaking the current site compilation.
- Modifying `update.sh` to fail-fast with `set -e` and report centralized errors matches the required strict error-handling strategy for scripts. 

### Alternatives Not Chosen
- Leaving `update.sh` to log to standard error natively was rejected because the directive strictly requires funneling errors via a centralized mechanism like `reportError`. 

### How To Pivot
- If the chosen pinned Hugo version causes issues, it can easily be updated by modifying `mise.toml` and `.github/workflows/gh-pages.yaml`.

### Next Knobs
- The `mise.toml` version of Hugo can be bumped up or down based on further testing.
- Additional constraints or directives can be added to the newly created `AGENTS.md` file as project conventions evolve.

---
*PR created automatically by Jules for task [7517148013856357181](https://jules.google.com/task/7517148013856357181) started by @lucasew*